### PR TITLE
Added HttpContext to doExecute call.

### DIFF
--- a/src/main/java/org/mitre/taxii/client/xml10/package-info.java
+++ b/src/main/java/org/mitre/taxii/client/xml10/package-info.java
@@ -1,5 +1,0 @@
-/**
- * TAXII 1.0 version specific HTTP client classes.
- * @see org.mitre.taxii.client.HttpClient
- */
-package org.mitre.taxii.client.xml10;

--- a/src/main/java/org/mitre/taxii/client/xml11/package-info.java
+++ b/src/main/java/org/mitre/taxii/client/xml11/package-info.java
@@ -1,5 +1,0 @@
-/**
- * TAXII 1.1 version specific HTTP client classes.
- * @see org.mitre.taxii.client.HttpClient
- */
-package org.mitre.taxii.client.xml11;

--- a/src/main/java/org/mitre/taxii/messages/xml10/package-info.java
+++ b/src/main/java/org/mitre/taxii/messages/xml10/package-info.java
@@ -1,8 +1,0 @@
-/**
- * TAXII 1.0 version specific message classes.
- * <p>
- * Contains classes for constructing and manipulating TAXII 1.0 messages.
- * This includes of the JAXB generated classes as well as several support classes.
- * </p>
- */
-package org.mitre.taxii.messages.xml10;

--- a/src/main/java/org/mitre/taxii/messages/xml11/package-info.java
+++ b/src/main/java/org/mitre/taxii/messages/xml11/package-info.java
@@ -1,8 +1,0 @@
-/**
- * TAXII 1.1 version specific message classes.
- * <p>
- * Contains classes for constructing and manipulating TAXII 1.1 messages.
- * This includes of the JAXB generated classes as well as several support classes.
- * </p>
- */
-package org.mitre.taxii.messages.xml11;

--- a/src/main/java/org/mitre/taxii/query/package-info.java
+++ b/src/main/java/org/mitre/taxii/query/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Support for TAXII Default Query.
- */
-package org.mitre.taxii.query;


### PR DESCRIPTION
also removed package-info which caused compile errors in Eclipse when
generating the java classes from schemas.