### PR TITLE
Use utf-8 encoding on request string, instead of default ISO_8859_1, …

### DIFF
--- a/src/main/java/org/mitre/taxii/client/HttpClient.java
+++ b/src/main/java/org/mitre/taxii/client/HttpClient.java
@@ -290,7 +290,7 @@ public class HttpClient {
             String requestStr = sw.toString();
 
             // Put the XML string in an entiny for the Request.
-            StringEntity reqEntity = new StringEntity(requestStr);
+            StringEntity reqEntity = new StringEntity(requestStr, "UTF-8");
             postRequest.setEntity(reqEntity);
 
             // Do the request


### PR DESCRIPTION
…to avoid sending server unknown characters